### PR TITLE
Add server component and background WebSocket handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bgio/node_modules/
 bgio/cache/
 bgio/.parcel-cache/
+server/node_modules/
+server/package-lock.json

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,46 @@
+let ws;
+
+function connect() {
+  ws = new WebSocket('ws://localhost:3001');
+
+  ws.onopen = () => {
+    console.log('WebSocket connected');
+  };
+
+  ws.onclose = () => {
+    setTimeout(connect, 1000);
+  };
+
+  ws.onmessage = (event) => {
+    let msg;
+    try {
+      msg = JSON.parse(event.data);
+    } catch {
+      return;
+    }
+    if (msg.query && msg.id) {
+      handleQuery(msg.id, msg.query);
+    }
+  };
+}
+
+function handleQuery(id, query) {
+  chrome.tabs.query({ url: '*://chat.openai.com/*' }, (tabs) => {
+    if (!tabs.length) {
+      ws.send(JSON.stringify({ id, answer: 'No ChatGPT tab found' }));
+      return;
+    }
+    const tabId = tabs[0].id;
+    chrome.tabs.sendMessage(tabId, { type: 'ASK_GPT', text: query }, (res) => {
+      if (chrome.runtime.lastError) {
+        ws.send(JSON.stringify({ id, answer: chrome.runtime.lastError.message }));
+      } else if (res && res.text) {
+        ws.send(JSON.stringify({ id, answer: res.text }));
+      } else {
+        ws.send(JSON.stringify({ id, answer: '' }));
+      }
+    });
+  });
+}
+
+connect();

--- a/chrome-extension/content.js
+++ b/chrome-extension/content.js
@@ -1,0 +1,36 @@
+function sendGPTQuery(text, sendResponse) {
+  const textarea = document.querySelector('textarea');
+  if (!textarea) {
+    sendResponse({ text: 'Textarea not found' });
+    return;
+  }
+  textarea.focus();
+  textarea.value = text;
+  textarea.dispatchEvent(new Event('input', { bubbles: true }));
+  const sendButton = document.querySelector('textarea + button');
+  if (sendButton) {
+    sendButton.click();
+  } else {
+    textarea.form.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+  }
+
+  const observer = new MutationObserver((mutations, obs) => {
+    const messages = document.querySelectorAll('main .markdown');
+    if (messages.length) {
+      const last = messages[messages.length - 1];
+      const text = last.textContent.trim();
+      if (text) {
+        obs.disconnect();
+        sendResponse({ text });
+      }
+    }
+  });
+  observer.observe(document.body, { childList: true, subtree: true });
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (msg.type === 'ASK_GPT') {
+    sendGPTQuery(msg.text, sendResponse);
+    return true; // keep channel open for async response
+  }
+});

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifest_version": 3,
+  "name": "ChatGPT Tab Interface",
+  "version": "1.0",
+  "description": "Send queries to ChatGPT in an open tab and return the response.",
+  "permissions": ["tabs", "scripting", "activeTab"],
+  "host_permissions": ["https://chat.openai.com/*"],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "content_scripts": [
+    {
+      "matches": ["https://chat.openai.com/*"],
+      "js": ["content.js"]
+    }
+  ]
+}

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    body { min-width: 220px; font-family: Arial, sans-serif; margin: 10px; }
+    textarea { width: 100%; }
+    pre { white-space: pre-wrap; word-wrap: break-word; }
+  </style>
+</head>
+<body>
+  <textarea id="query" rows="4" placeholder="Type your question..."></textarea>
+  <button id="send">Send</button>
+  <pre id="response"></pre>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -1,0 +1,21 @@
+document.getElementById('send').addEventListener('click', () => {
+  const query = document.getElementById('query').value.trim();
+  if (!query) return;
+
+  chrome.tabs.query({ url: '*://chat.openai.com/*' }, (tabs) => {
+    if (!tabs.length) {
+      document.getElementById('response').textContent = 'No ChatGPT tab found.';
+      return;
+    }
+    const tabId = tabs[0].id;
+    chrome.tabs.sendMessage(tabId, { type: 'ASK_GPT', text: query }, (res) => {
+      if (chrome.runtime.lastError) {
+        document.getElementById('response').textContent = 'Error: ' + chrome.runtime.lastError.message;
+      } else if (res && res.text) {
+        document.getElementById('response').textContent = res.text;
+      } else {
+        document.getElementById('response').textContent = 'No response received.';
+      }
+    });
+  });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "chatgpt-extension-server",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "express": "^4.18.2",
+    "ws": "^8.13.0"
+  }
+}

--- a/server/server.js
+++ b/server/server.js
@@ -1,0 +1,53 @@
+import express from 'express';
+import { WebSocketServer } from 'ws';
+
+const app = express();
+app.use(express.json());
+
+let extensionSocket = null;
+const pending = new Map();
+let nextId = 1;
+
+app.post('/ask', (req, res) => {
+  const query = req.body.query;
+  if (!query) {
+    res.status(400).json({ error: 'Missing query' });
+    return;
+  }
+  if (!extensionSocket || extensionSocket.readyState !== 1) {
+    res.status(503).json({ error: 'Extension not connected' });
+    return;
+  }
+  const id = nextId++;
+  pending.set(id, res);
+  extensionSocket.send(JSON.stringify({ id, query }));
+});
+
+const server = app.listen(3001, () => {
+  console.log('HTTP server listening on http://localhost:3001');
+});
+
+const wss = new WebSocketServer({ noServer: true });
+
+server.on('upgrade', (request, socket, head) => {
+  wss.handleUpgrade(request, socket, head, (ws) => {
+    extensionSocket = ws;
+    console.log('Extension connected');
+    ws.on('message', (data) => {
+      let msg;
+      try {
+        msg = JSON.parse(data);
+      } catch {
+        return;
+      }
+      if (msg.id && pending.has(msg.id)) {
+        const res = pending.get(msg.id);
+        pending.delete(msg.id);
+        res.json({ answer: msg.answer });
+      }
+    });
+    ws.on('close', () => {
+      extensionSocket = null;
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- create a small Node server exposing `/ask` and a WebSocket endpoint
- add Chrome extension background service worker that relays WS messages to ChatGPT
- update manifest to register the background script
- ignore server dependencies in `.gitignore`

## Testing
- `npm test --silent` *(no output)*
- `node server.js` *(started successfully)*

------
https://chatgpt.com/codex/tasks/task_e_684490529b648331bd95e362ff648051